### PR TITLE
Add support for entities split into multiple documents

### DIFF
--- a/packages/soukai-solid/src/models/SolidModel.test.ts
+++ b/packages/soukai-solid/src/models/SolidModel.test.ts
@@ -544,6 +544,38 @@ describe('SolidModel', () => {
         expect(movie).toBeNull();
     });
 
+    it('finds model in document not matching its id', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+
+        const person = new Person({ 
+            url: resourceUrl,
+            name: 'Alice',
+        });
+
+        FakeSolidEngine.database[sourceContainerUrl] = {
+            [sourceDocumentUrl]: {
+                '@graph': [
+                    person.toJsonLD() as EngineDocument,
+                ],
+            },
+        };
+
+        // Act
+        const loadedPerson = await Person.find(resourceUrl, sourceDocumentUrl);
+
+        // Assert
+        expect(loadedPerson).not.toBeNull();
+        expect(loadedPerson?.getSourceDocumentUrl()).toEqual(sourceDocumentUrl);
+        expect(loadedPerson?.url).toEqual(person.url);
+        expect(loadedPerson?.name).toEqual(person.name);
+    });
+
     it('converts filters to JSON-LD', async () => {
         // Arrange
         const peopleUrl = 'https://example.com/people/';
@@ -1093,6 +1125,57 @@ describe('SolidModel', () => {
         });
     });
 
+    it('creates models in existing documents not matching their id', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const movieUrl = fakeResourceUrl({ documentUrl });
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+        const movie = new Movie({ url: movieUrl });
+
+        movie.setDocumentExists(true);
+        movie.setSourceDocumentUrl(sourceDocumentUrl);
+
+        FakeSolidEngine.database[sourceContainerUrl] = { [sourceDocumentUrl]: { '@graph': [] } as EngineDocument };
+
+        // Act
+        await movie.save();
+
+        // Assert
+        expect(FakeSolidEngine.update).toHaveBeenCalledWith(expect.anything(), sourceDocumentUrl, {
+            '@graph': {
+                $push: movie.toJsonLD(),
+            },
+        });
+    });
+
+    it('creates models in non-existing documents not matching their id', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const movieUrl = fakeResourceUrl({ documentUrl });
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+        const movie = new Movie({ url: movieUrl });
+
+        movie.setSourceDocumentUrl(sourceDocumentUrl);
+
+        // Act
+        await movie.save();
+
+        // Assert
+        expect(FakeSolidEngine.create).toHaveBeenCalledWith(
+            expect.anything(), 
+            {
+                '@graph': [
+                    movie.toJsonLD() as EngineDocument,
+                ],
+            },
+            sourceDocumentUrl,
+        );
+    });
+
     it('updates models', async () => {
         // Arrange
         const containerUrl = fakeContainerUrl();
@@ -1118,6 +1201,36 @@ describe('SolidModel', () => {
             },
         });
     });
+
+    it('updates models in documents not matching their id', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const movieName = faker.lorem.sentence();
+        const movieUrl = fakeResourceUrl({ documentUrl });
+        const movie = new Movie({ url: movieUrl }, true);
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+        movie.setSourceDocumentUrl(sourceDocumentUrl);
+
+        movie.title = movieName;
+
+        FakeSolidEngine.database[sourceContainerUrl] = { [sourceDocumentUrl]: { '@graph': [movie.toJsonLD()] } as EngineDocument };
+
+        // Act
+        await movie.save();
+
+        // Assert
+        expect(FakeSolidEngine.update).toHaveBeenCalledWith(expect.anything(), sourceDocumentUrl, {
+            '@graph': {
+                $updateItems: {
+                    $where: { '@id': movieUrl },
+                    $update: { [IRI('schema:name')]: movieName },
+                },
+            },
+        });
+    });
+
 
     it('uses model url container on find', async () => {
         // Arrange
@@ -1158,6 +1271,32 @@ describe('SolidModel', () => {
         expect(collection).toEqual(containerUrl);
     });
 
+    it('uses model source document url container on save', async () => {
+        // Arrange
+        class StubModel extends SolidModel {}
+
+        bootModels({ StubModel });
+
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+
+        const model = new StubModel({ url: fakeDocumentUrl({ containerUrl }) }, true);
+        model.setSourceDocumentUrl(sourceDocumentUrl);
+
+        FakeSolidEngine.database[sourceContainerUrl] = {
+            [sourceDocumentUrl]: { '@graph': [model.toJsonLD()] } as EngineDocument,
+        };
+
+        // Act
+        await model.update({ name: 'John' });
+
+        // Assert
+        const collection = FakeSolidEngine.updateSpy.mock.calls[0]?.[0];
+
+        expect(collection).toEqual(sourceContainerUrl);
+    });
+
     it('deletes the entire document if all stored resources are deleted', async () => {
         // Arrange
         const containerUrl = fakeContainerUrl();
@@ -1180,6 +1319,34 @@ describe('SolidModel', () => {
         expect(FakeSolidEngine.delete).toHaveBeenCalledWith(containerUrl, documentUrl);
     });
 
+    it('deletes the entire document not matching model\'s id if all stored resources are deleted', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+        const movieUrl = `${documentUrl}#it`;
+        const actionUrl = `${documentUrl}#action`;
+        const movie = new Movie({ url: movieUrl }, true);
+        movie.setSourceDocumentUrl(sourceDocumentUrl);
+
+        const action = new WatchAction({ url: actionUrl }, true);
+        action.setSourceDocumentUrl(sourceDocumentUrl);
+
+        movie.setRelationModels('actions', [action]);
+
+        FakeSolidEngine.database[sourceContainerUrl] = {
+            [sourceDocumentUrl]: { '@graph': [{ '@id': movieUrl }, { '@id': actionUrl }] },
+        };
+
+        // Act
+        await movie.delete();
+
+        // Assert
+        expect(FakeSolidEngine.delete).toHaveBeenCalledTimes(1);
+        expect(FakeSolidEngine.delete).toHaveBeenCalledWith(sourceContainerUrl, sourceDocumentUrl);
+    });
+
     it('deletes only model properties if the document has other resources', async () => {
         // Arrange
         class StubModel extends SolidModel {}
@@ -1200,6 +1367,38 @@ describe('SolidModel', () => {
         // Assert
         expect(FakeSolidEngine.update).toHaveBeenCalledTimes(1);
         expect(FakeSolidEngine.update).toHaveBeenCalledWith(containerUrl, documentUrl, {
+            '@graph': {
+                $updateItems: {
+                    $where: { '@id': { $in: [url] } },
+                    $unset: true,
+                },
+            },
+        });
+    });
+
+    it('deletes only model properties if the document not matching model\'s id has other resources', async () => {
+        // Arrange
+        class StubModel extends SolidModel {}
+        bootModels({ StubModel });
+
+        const containerUrl = fakeContainerUrl({ baseUrl: 'https://example.org/' });
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const sourceContainerUrl = fakeContainerUrl({ baseUrl: 'https://example.com/' });
+        const sourceDocumentUrl = fakeDocumentUrl({ containerUrl: sourceContainerUrl });
+        const url = `${documentUrl}#it`;
+        const model = new StubModel({ url, name: faker.name.firstName() }, true);
+        model.setSourceDocumentUrl(sourceDocumentUrl);
+
+        FakeSolidEngine.database[sourceContainerUrl] = {
+            [sourceDocumentUrl]: { '@graph': [{ '@id': `${sourceDocumentUrl}#something-else` }] },
+        };
+
+        // Act
+        await model.delete();
+
+        // Assert
+        expect(FakeSolidEngine.update).toHaveBeenCalledTimes(1);
+        expect(FakeSolidEngine.update).toHaveBeenCalledWith(sourceContainerUrl, sourceDocumentUrl, {
             '@graph': {
                 $updateItems: {
                     $where: { '@id': { $in: [url] } },

--- a/packages/soukai-solid/src/models/SolidModel.test.ts
+++ b/packages/soukai-solid/src/models/SolidModel.test.ts
@@ -35,6 +35,7 @@ import { defineSolidModelSchema } from 'soukai-solid/models/schema';
 import { XSD_DATE_TIME } from 'soukai-solid/solid/constants';
 
 import Group from 'soukai-solid/testing/lib/stubs/Group';
+import ModelWithCustomKey from 'soukai-solid/testing/lib/stubs/ModelWithCustomKey';
 import Movie from 'soukai-solid/testing/lib/stubs/Movie';
 import MoviesCollection from 'soukai-solid/testing/lib/stubs/MoviesCollection';
 import Person from 'soukai-solid/testing/lib/stubs/Person';
@@ -59,6 +60,7 @@ describe('SolidModel', () => {
             GroupWithHistory,
             GroupWithHistoryAndPersonsInSameDocument,
             GroupWithPersonsInSameDocument,
+            ModelWithCustomKey,
             Movie,
             MovieWithHistory,
             MoviesCollection,
@@ -1308,6 +1310,18 @@ describe('SolidModel', () => {
         expect(model.url).toEqual(model.id);
     });
 
+    it('aliases custom primary key attribute as id', async () => {
+        // Arrange
+        const model = new ModelWithCustomKey();
+
+        // Act
+        await model.save();
+
+        // Assert
+        expect(model.customKey).toBeTruthy();
+        expect(model.customKey).toEqual(model.id);
+    });
+
     it('implements belongs to many relationship', async () => {
         // Arrange
 
@@ -1460,6 +1474,39 @@ describe('SolidModel', () => {
             'knows': friendUrls.map((url) => ({ '@id': url })),
             'metadata': {
                 '@id': person.url + '#metadata',
+                '@type': 'crdt:Metadata',
+                'crdt:createdAt': {
+                    '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+                    '@value': '1997-07-21T23:42:00.000Z',
+                },
+            },
+        });
+    });
+
+    it('serializes to JSON-LD with custom primary key', () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const model = new ModelWithCustomKey({
+            customKey: fakeDocumentUrl({ containerUrl }),
+            age: 42,
+            createdAt: new Date('1997-07-21T23:42:00Z'),
+        });
+
+        // Act
+        const jsonld = model.toJsonLD();
+
+        // Assert
+        expect(jsonld).toEqual({
+            '@context': {
+                '@vocab': 'http://xmlns.com/foaf/0.1/',
+                'crdt': 'https://vocab.noeldemartin.com/crdt/',
+                'metadata': { '@reverse': 'crdt:resource' },
+            },
+            '@id': model.customKey,
+            '@type': 'ModelWithCustomKey',
+            'age': 42,
+            'metadata': {
+                '@id': model.customKey + '#metadata',
                 '@type': 'crdt:Metadata',
                 'crdt:createdAt': {
                     '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',

--- a/packages/soukai-solid/src/models/SolidModel.test.ts
+++ b/packages/soukai-solid/src/models/SolidModel.test.ts
@@ -36,6 +36,7 @@ import { XSD_DATE_TIME } from 'soukai-solid/solid/constants';
 
 import Group from 'soukai-solid/testing/lib/stubs/Group';
 import ModelWithCustomKey from 'soukai-solid/testing/lib/stubs/ModelWithCustomKey';
+import ModelWithoutType from 'soukai-solid/testing/lib/stubs/ModelWithoutType';
 import Movie from 'soukai-solid/testing/lib/stubs/Movie';
 import MoviesCollection from 'soukai-solid/testing/lib/stubs/MoviesCollection';
 import Person from 'soukai-solid/testing/lib/stubs/Person';
@@ -61,6 +62,7 @@ describe('SolidModel', () => {
             GroupWithHistoryAndPersonsInSameDocument,
             GroupWithPersonsInSameDocument,
             ModelWithCustomKey,
+            ModelWithoutType,
             Movie,
             MovieWithHistory,
             MoviesCollection,
@@ -331,6 +333,18 @@ describe('SolidModel', () => {
         expect(document['@graph'][0]['@type']).not.toBeUndefined();
     });
 
+    it('doesn\'t send types on create if class is null', async () => {
+        // Arrange
+
+        // Act
+        await ModelWithoutType.create({});
+
+        // Assert
+        const document = FakeSolidEngine.createSpy.mock.calls[0]?.[1] as { '@graph': [{ '@type': string }] };
+
+        expect(document['@graph'][0]['@type']).toBeUndefined();
+    });
+
     it('removes duplicated array values', async () => {
         // Arrange
         const url = fakeResourceUrl();
@@ -476,6 +490,23 @@ describe('SolidModel', () => {
         expect(ids).toEqual([`${documentUrl}#it`]);
     });
 
+    it('finds all resource ids if class is null', async () => {
+        // Arrange
+        const documentUrl = fakeDocumentUrl();
+        const quads = turtleToQuadsSync(`
+            <#it> a <https://schema.org/Action> .
+            <#second> <https://example.com/test> "Entity without type" .
+            `, {
+            baseIRI: documentUrl,
+        });
+
+        // Act
+        const ids = ModelWithoutType.findMatchingResourceIds(quads);
+
+        // Assert
+        expect(ids).toEqual([`${documentUrl}#it`]);
+    });
+
     it('sends JSON-LD with related model updates using parent engine', async () => {
         // Arrange
         const containerUrl = fakeContainerUrl();
@@ -574,6 +605,38 @@ describe('SolidModel', () => {
         expect(loadedPerson?.getSourceDocumentUrl()).toEqual(sourceDocumentUrl);
         expect(loadedPerson?.url).toEqual(person.url);
         expect(loadedPerson?.name).toEqual(person.name);
+    });
+
+    it('finds model with any class if class is null', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const otherResourceUrl = fakeResourceUrl({ documentUrl, hash: 'other' });
+
+        FakeSolidEngine.database[containerUrl] = {
+            [documentUrl]: { 
+                '@graph': [
+                    { 
+                        '@id': otherResourceUrl, 
+                        '@type': 'http://xmlns.com/foaf/0.1/Person',
+                        'http://xmlns.com/foaf/0.1/age': 30,
+                    },
+                    { 
+                        '@id': resourceUrl, 
+                        '@type': 'http://xmlns.com/foaf/0.1/Person',
+                        'http://xmlns.com/foaf/0.1/age': 35,
+                    },
+                ],
+            },
+        };
+
+        // Act
+        const model = await ModelWithoutType.at(containerUrl).find(resourceUrl);
+
+        // Assert
+        expect(model).not.toBeNull();
+        expect(model?.age).toEqual(35);
     });
 
     it('converts filters to JSON-LD', async () => {

--- a/packages/soukai-solid/src/models/SolidModel.ts
+++ b/packages/soukai-solid/src/models/SolidModel.ts
@@ -712,7 +712,9 @@ export class SolidModel extends SolidModelBase {
         }
     }
 
-    // TODO this should be optional
+    // Not used directly, because the primary key may be different. 
+    // It is left here for backward compatibility reasons,
+    // because users can extend this class directly without calling defineSolidModelSchema method.
     declare public url: string;
 
     declare public deletedAt?: Date;
@@ -875,7 +877,8 @@ export class SolidModel extends SolidModelBase {
         const model = this.clone();
 
         if (!options.ids) {
-            model.getRelatedModels().forEach((relatedModel) => relatedModel.setAttribute('url', null));
+            model.getRelatedModels().forEach((relatedModel) => 
+                relatedModel.setAttribute(relatedModel.static('primaryKey'), null));
         }
 
         if (!options.timestamps) {
@@ -906,7 +909,9 @@ export class SolidModel extends SolidModelBase {
     }
 
     public getIdAttribute(): string {
-        return this.getAttribute('url');
+        // id is defined as string, but in reality it can be undefined.
+        // For backward compatibility reasons, this method can return undefined.
+        return this.getSerializedPrimaryKey() ?? undefined as unknown as string;
     }
 
     public setExists(exists: boolean): void {
@@ -1012,7 +1017,8 @@ export class SolidModel extends SolidModelBase {
     }
 
     public getDocumentUrl(): string | null {
-        return this.url ? urlRoute(this.url) : null;
+        const id = this.getSerializedPrimaryKey();
+        return id ? urlRoute(id) : null;
     }
 
     public requireDocumentUrl(): string {
@@ -1287,7 +1293,7 @@ export class SolidModel extends SolidModelBase {
 
         await super.beforeSave();
 
-        if (!this.url && this.static('mintsUrls') && !usingExperimentalActivityPods()) {
+        if (!this.getPrimaryKey() && this.static('mintsUrls') && !usingExperimentalActivityPods()) {
             this.mintUrl();
         }
 
@@ -1341,7 +1347,7 @@ export class SolidModel extends SolidModelBase {
             this.static('defaultResourceHash') &&
             !usingExperimentalActivityPods()
         ) {
-            this.metadata.resourceUrl = this.url ?? `#${this.static('defaultResourceHash')}`;
+            this.metadata.resourceUrl = this.getSerializedPrimaryKey() ?? `#${this.static('defaultResourceHash')}`;
             this.metadata.mintUrl(this.getDocumentUrl() || undefined, this._documentExists);
         }
     }
@@ -1377,7 +1383,10 @@ export class SolidModel extends SolidModelBase {
         } catch (error) {
             if (!(error instanceof DocumentAlreadyExists)) throw error;
 
-            this.url = this.newUniqueUrl(this.url);
+            const newUrl = this.newUniqueUrl(
+                this.getSerializedPrimaryKey() ?? fail('The primary key was not created before save.'),
+            );
+            this.setAttribute(this.static('primaryKey'), newUrl);
 
             await super.performSave();
         }
@@ -1402,8 +1411,9 @@ export class SolidModel extends SolidModelBase {
             return;
         }
 
-        if (this.metadata && this.metadata.resourceUrl !== this.url) {
-            this.metadata.resourceUrl = this.url;
+        if (this.metadata && this.metadata.resourceUrl !== this.getSerializedPrimaryKey()) {
+            this.metadata.resourceUrl = this.getSerializedPrimaryKey()
+                ?? fail('The primary key is not set after save.');
 
             if (!usingExperimentalActivityPods()) {
                 this.metadata.mintUrl(this.getDocumentUrl() || undefined, this._documentExists);
@@ -1638,14 +1648,14 @@ export class SolidModel extends SolidModelBase {
                 removedModel.getDocumentModels().forEach((model) =>
                     graphUpdates.push({
                         $updateItems: {
-                            $where: { '@id': model.url },
+                            $where: { '@id': model.getSerializedPrimaryKey() },
                             $unset: true,
                         },
                     }));
             }
         }
 
-        if (super.isDirty() && this.url) {
+        if (super.isDirty() && this.getPrimaryKey()) {
             const modelUpdates = super.getDirtyEngineDocumentUpdates();
 
             // This is necessary because a SolidEngine behaves differently than other engines.
@@ -1655,7 +1665,7 @@ export class SolidModel extends SolidModelBase {
 
             graphUpdates.push({
                 $updateItems: {
-                    $where: { '@id': this.url },
+                    $where: { '@id': this.getSerializedPrimaryKey() },
                     $update: this.convertEngineUpdatesToJsonLD(modelUpdates, compactIRIs),
                 },
             });
@@ -1748,9 +1758,12 @@ export class SolidModel extends SolidModelBase {
     }
 
     protected guessCollection(): string | undefined {
-        if (!this.url) return;
-
-        return urlParentDirectory(this.url) ?? undefined;
+        const url = this.getSerializedPrimaryKey();
+        if (!url) {
+            return undefined;
+        }
+ 
+        return urlParentDirectory(url) ?? undefined;
     }
 
     protected mintDocumentModelsKeys(models: SolidModel[]): void {
@@ -1759,7 +1772,9 @@ export class SolidModel extends SolidModelBase {
 
         // Mint primary keys
         for (const documentModel of models) {
-            if (documentModel.url) continue;
+            if (documentModel.getPrimaryKey()) {
+                continue;
+            }
 
             documentModel.mintUrl(documentUrl, documentExists, uuid());
         }

--- a/packages/soukai-solid/src/models/SolidModel.ts
+++ b/packages/soukai-solid/src/models/SolidModel.ts
@@ -337,10 +337,20 @@ export class SolidModel extends SolidModelBase {
 
     public static async findOrFail<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T>;
     public static async findOrFail<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T>;
-    public static async findOrFail<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T> {
+    public static async findOrFail<T extends SolidModel>(
+        this: SolidModelConstructor<T>,
+        id: Key,
+        documentUrl?: string
+    ): Promise<T>;
+
+    public static async findOrFail<T extends SolidModel>(
+        this: SolidModelConstructor<T>,
+        id: Key,
+        documentUrl?: string,
+    ): Promise<T> {
         const rdfsClasses = arrayUnique([this.rdfsClasses, ...this.rdfsClassesAliases].flat());
         const resourceUrl = this.instance().serializeKey(id);
-        const documentUrl = urlRoute(resourceUrl);
+        documentUrl ??= urlRoute(resourceUrl);
         const containerUrl = urlParentDirectory(documentUrl) ?? urlRoot(documentUrl);
 
         this.ensureBooted();
@@ -364,9 +374,19 @@ export class SolidModel extends SolidModelBase {
 
     public static async find<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T | null>;
     public static async find<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T | null>;
-    public static async find<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T | null> {
+    public static async find<T extends SolidModel>(
+        this: SolidModelConstructor<T>,
+        id: Key,
+        documentUrl?: string
+    ): Promise<T | null>;
+    
+    public static async find<T extends SolidModel>(
+        this: SolidModelConstructor<T>,
+        id: Key,
+        documentUrl?: string,
+    ): Promise<T | null> {
         try {
-            return await this.findOrFail(id);
+            return await this.findOrFail(id, documentUrl);
         } catch (error) {
             if (
                 applyStrictChecks() &&
@@ -864,6 +884,7 @@ export class SolidModel extends SolidModelBase {
 
         if (documentUrl) {
             this._documentExists = documentExists ?? true;
+            this.setSourceDocumentUrl(documentUrl);
         }
     }
 
@@ -1017,6 +1038,11 @@ export class SolidModel extends SolidModelBase {
     }
 
     public getDocumentUrl(): string | null {
+        const sourceDocumentUrl = this.getSourceDocumentUrl();
+        if (sourceDocumentUrl) {
+            return sourceDocumentUrl;
+        }
+
         const id = this.getSerializedPrimaryKey();
         return id ? urlRoute(id) : null;
     }
@@ -1383,10 +1409,15 @@ export class SolidModel extends SolidModelBase {
         } catch (error) {
             if (!(error instanceof DocumentAlreadyExists)) throw error;
 
-            const newUrl = this.newUniqueUrl(
-                this.getSerializedPrimaryKey() ?? fail('The primary key was not created before save.'),
-            );
-            this.setAttribute(this.static('primaryKey'), newUrl);
+            if (this.getSourceDocumentUrl()) {
+                this.setDocumentExists(true);
+            }
+            else {
+                const newUrl = this.newUniqueUrl(
+                    this.getSerializedPrimaryKey() ?? fail('The primary key was not created before save.'),
+                );
+                this.setAttribute(this.static('primaryKey'), newUrl);
+            }
 
             await super.performSave();
         }
@@ -1758,12 +1789,12 @@ export class SolidModel extends SolidModelBase {
     }
 
     protected guessCollection(): string | undefined {
-        const url = this.getSerializedPrimaryKey();
-        if (!url) {
+        const documentUrl = this.getDocumentUrl();
+        if (!documentUrl) {
             return undefined;
         }
  
-        return urlParentDirectory(url) ?? undefined;
+        return urlParentDirectory(documentUrl) ?? undefined;
     }
 
     protected mintDocumentModelsKeys(models: SolidModel[]): void {

--- a/packages/soukai-solid/src/models/SolidModel.ts
+++ b/packages/soukai-solid/src/models/SolidModel.ts
@@ -138,7 +138,7 @@ export class SolidModel extends SolidModelBase {
     public static classFields = ['_history', '_publicPermissions', '_tombstone'];
     public static rdfContext?: string;
     public static rdfContexts: RDFContexts = {};
-    public static rdfsClass?: string;
+    public static rdfsClass?: string | null;
     public static rdfsClasses: string[] = [];
     public static rdfsClassesAliases: string[][] = [];
     public static reservedRelations: string[] = ['metadata', 'operations', 'tombstone', 'authorizations'];
@@ -248,7 +248,7 @@ export class SolidModel extends SolidModelBase {
             this.rdfsClass,
         );
         this.rdfsClasses = this.bootRdfsClasses(
-            Object.getOwnPropertyDescriptor(this, 'rdfsClass')?.value ?? null,
+            Object.getOwnPropertyDescriptor(this, 'rdfsClass')?.value,
             Object.getOwnPropertyDescriptor(this, 'rdfsClasses')?.value ?? null,
             this.rdfContexts,
         );
@@ -359,7 +359,7 @@ export class SolidModel extends SolidModelBase {
         const document = await this.requireEngine().readOne(containerUrl, documentUrl);
         const resource = await RDFDocument.resourceFromJsonLDGraph(document as JsonLDGraph, resourceUrl);
 
-        if (!rdfsClasses.some((type) => resource.isType(type))) {
+        if (rdfsClasses.length > 0 && !rdfsClasses.some((type) => resource.isType(type))) {
             return fail(ResourceNotFound, resourceUrl, documentUrl);
         }
 
@@ -548,14 +548,16 @@ export class SolidModel extends SolidModelBase {
         );
 
         return Object.entries(resourcesTypes)
-            .filter(([_, types]) => types.some((type) => this.rdfsClasses.includes(type)))
+            .filter(([_, types]) => 
+                this.rdfsClasses.length === 0 
+                || types.some((type) => this.rdfsClasses.includes(type)))
             .map(([resourceId]) => (baseUrl ? urlResolve(baseUrl, resourceId) : resourceId));
     }
 
     protected static bootRdfContexts(
         rdfContext: string | null,
         rdfContexts: RDFContexts,
-        rdfsClass: string | undefined,
+        rdfsClass: string | null | undefined,
         options: { modelClass?: typeof SolidModel; skipParentSchema?: boolean } = {},
     ): RDFContexts {
         const modelClass = options.modelClass ?? this;
@@ -605,7 +607,7 @@ export class SolidModel extends SolidModelBase {
     }
 
     protected static bootRdfsClasses(
-        rdfsClass: string | null,
+        rdfsClass: string | null | undefined,
         rdfsClasses: string[] | null,
         rdfContexts: RDFContexts,
         initialClass?: typeof SolidModel,
@@ -620,6 +622,10 @@ export class SolidModel extends SolidModelBase {
             return [this.rdfTerm(rdfsClass, rdfContexts)];
         }
 
+        if (rdfsClass === null) {
+            return [];
+        }
+
         const parentModelClass = Object.getPrototypeOf(modelClass);
 
         if (!parentModelClass) {
@@ -627,7 +633,7 @@ export class SolidModel extends SolidModelBase {
         }
 
         return this.bootRdfsClasses(
-            Object.getOwnPropertyDescriptor(parentModelClass, 'rdfsClass')?.value ?? null,
+            Object.getOwnPropertyDescriptor(parentModelClass, 'rdfsClass')?.value,
             Object.getOwnPropertyDescriptor(parentModelClass, 'rdfsClasses')?.value ?? null,
             {
                 ...rdfContexts,
@@ -711,7 +717,7 @@ export class SolidModel extends SolidModelBase {
                 schema.rdfsClass,
                 { skipParentSchema: true },
             );
-            const rdfsClasses = this.bootRdfsClasses(schema.rdfsClass ?? null, schema.rdfsClasses ?? null, rdfContexts);
+            const rdfsClasses = this.bootRdfsClasses(schema.rdfsClass, schema.rdfsClasses ?? null, rdfContexts);
             const rdfsClassesAliases = this.bootRdfsClassesAliases(schema.rdfsClassesAliases ?? [], rdfContexts);
 
             startSchemaUpdate(this, rdfContexts);
@@ -1271,7 +1277,8 @@ export class SolidModel extends SolidModelBase {
                     rdfDocument.resources
                         .filter(
                             (resource): resource is RDFResource & { url: string } =>
-                                !!resource.url && rdfsClasses.some((type) => resource.isType(type)),
+                                !!resource.url 
+                                && (rdfsClasses.length === 0 || rdfsClasses.some((type) => resource.isType(type))),
                         )
                         .map(async (resource) => {
                             try {

--- a/packages/soukai-solid/src/models/SolidModel.ts
+++ b/packages/soukai-solid/src/models/SolidModel.ts
@@ -335,9 +335,9 @@ export class SolidModel extends SolidModelBase {
     }
     /* eslint-enable max-len */
 
-    public static async find<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T | null>;
-    public static async find<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T | null>;
-    public static async find<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T | null> {
+    public static async findOrFail<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T>;
+    public static async findOrFail<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T>;
+    public static async findOrFail<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T> {
         const rdfsClasses = arrayUnique([this.rdfsClasses, ...this.rdfsClassesAliases].flat());
         const resourceUrl = this.instance().serializeKey(id);
         const documentUrl = urlRoute(resourceUrl);
@@ -345,22 +345,28 @@ export class SolidModel extends SolidModelBase {
 
         this.ensureBooted();
 
+        const { documentPermissions, stopTracking } = this.instance().trackPublicPermissions();
+        const document = await this.requireEngine().readOne(containerUrl, documentUrl);
+        const resource = await RDFDocument.resourceFromJsonLDGraph(document as JsonLDGraph, resourceUrl);
+
+        if (!rdfsClasses.some((type) => resource.isType(type))) {
+            return fail(ResourceNotFound, resourceUrl, documentUrl);
+        }
+
+        const model = await this.instance().createFromEngineDocument(documentUrl, document, resourceUrl);
+
+        stopTracking();
+
+        model._publicPermissions = documentPermissions[documentUrl];
+
+        return model;
+    }
+
+    public static async find<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T | null>;
+    public static async find<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T | null>;
+    public static async find<T extends SolidModel>(this: SolidModelConstructor<T>, id: Key): Promise<T | null> {
         try {
-            const { documentPermissions, stopTracking } = this.instance().trackPublicPermissions();
-            const document = await this.requireEngine().readOne(containerUrl, documentUrl);
-            const resource = await RDFDocument.resourceFromJsonLDGraph(document as JsonLDGraph, resourceUrl);
-
-            if (!rdfsClasses.some((type) => resource.isType(type))) {
-                return null;
-            }
-
-            const model = await this.instance().createFromEngineDocument(documentUrl, document, resourceUrl);
-
-            stopTracking();
-
-            model._publicPermissions = documentPermissions[documentUrl];
-
-            return model;
+            return await this.findOrFail(id);
         } catch (error) {
             if (
                 applyStrictChecks() &&

--- a/packages/soukai-solid/src/models/SolidMultiDocumentModel.test.ts
+++ b/packages/soukai-solid/src/models/SolidMultiDocumentModel.test.ts
@@ -1,0 +1,505 @@
+import { faker } from '@noeldemartin/faker';
+import { fakeContainerUrl, fakeDocumentUrl, fakeResourceUrl } from '@noeldemartin/testing';
+import { type EngineDocument, bootModels } from 'soukai';
+import FakeSolidEngine from 'soukai-solid/testing/fakes/FakeSolidEngine';
+import { stubPersonJsonLD, stubWebIdJsonLD } from 'soukai-solid/testing/lib/stubs/helpers';
+import { MultiDocumentWebId } from 'soukai-solid/testing/lib/stubs/MultiDocumentWebId';
+import Person from 'soukai-solid/testing/lib/stubs/Person';
+import WebId from 'soukai-solid/testing/lib/stubs/WebId';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+describe('SolidMultiDocumentModel', () => {
+
+    beforeAll(() => {
+        bootModels({
+            
+        });
+    });
+
+    beforeEach(() => {
+        FakeSolidEngine.reset();
+        FakeSolidEngine.use();
+    });
+
+    it('finds model in single document', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl, hash: 'res' });
+        const otherResourceUrl = fakeResourceUrl({ documentUrl, hash: 'other' });
+        const name = faker.name.firstName();
+
+        FakeSolidEngine.database[containerUrl] = {
+            [documentUrl]: {
+                '@graph': [
+                    stubPersonJsonLD(otherResourceUrl, name + '2')['@graph'][0],
+                    stubWebIdJsonLD(resourceUrl, name)['@graph'][0],
+                ],
+            } as EngineDocument,
+        };
+
+        // Act
+        const model = await MultiDocumentWebId.find(resourceUrl);
+
+        // Assert
+        expect(model).not.toBeNull();
+        expect(model?.getParts().length).toEqual(1);
+        expect(model?.getParts()[0]?.name).toEqual(name);
+    });
+
+    it('finds model in linked documents', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const firstDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'main' });
+        const resourceUrl = fakeResourceUrl({ documentUrl: firstDocumentUrl });
+        const linkedDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'other' });
+
+        const name = faker.name.firstName();
+
+        FakeSolidEngine.database[containerUrl] = {
+            [firstDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '1', [], [linkedDocumentUrl]),
+            [linkedDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '2'),
+        };
+
+        // Act
+        const model = await MultiDocumentWebId.find(resourceUrl);
+
+        // Assert
+        expect(model).not.toBeNull();
+        expect(model?.getParts().length).toEqual(2);
+        expect(model?.getParts()[0]?.name).toEqual(name + '1');
+        expect(model?.getParts()[1]?.name).toEqual(name + '2');
+    });
+
+    it('finds model in linked documents recursively', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const firstDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'main' });
+        const resourceUrl = fakeResourceUrl({ documentUrl: firstDocumentUrl });
+        const linkedDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'other' });
+        const recursivelyLinkedDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'recursion' });
+        const anotherRecursivelyLinkedDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'another-recursion' });
+
+        const name = faker.name.firstName();
+
+        FakeSolidEngine.database[containerUrl] = {
+            [firstDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '1', [], [linkedDocumentUrl]),
+            [linkedDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '2', [], [], [recursivelyLinkedDocumentUrl]),
+            [recursivelyLinkedDocumentUrl]: stubWebIdJsonLD(
+                resourceUrl,
+                name + '3',
+                [],
+                [anotherRecursivelyLinkedDocumentUrl, linkedDocumentUrl],
+                [recursivelyLinkedDocumentUrl],
+            ),
+        };
+
+        // Act
+        const model = await MultiDocumentWebId.find(resourceUrl);
+
+        // Assert
+        expect(model).not.toBeNull();
+        expect(model?.getParts().length).toEqual(3);
+        expect(model?.getParts()[0]?.name).toEqual(name + '1');
+        expect(model?.getParts()[1]?.name).toEqual(name + '2');
+        expect(model?.getParts()[2]?.name).toEqual(name + '3');
+    });
+
+    it('finds model in linked documents with start in document not matching id', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const resourceDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'res' });
+        const resourceUrl = fakeResourceUrl({ documentUrl: resourceDocumentUrl });
+        const firstDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'main' });
+        const linkedDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'other' });
+
+        const name = faker.name.firstName();
+
+        FakeSolidEngine.database[containerUrl] = {
+            [firstDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '1', [], [linkedDocumentUrl]),
+            [linkedDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '2'),
+        };
+
+        // Act
+        const model = await MultiDocumentWebId.find(resourceUrl, firstDocumentUrl);
+
+        // Assert
+        expect(model).not.toBeNull();
+        expect(model?.getParts().length).toEqual(2);
+        expect(model?.getParts()[0]?.name).toEqual(name + '1');
+        expect(model?.getParts()[1]?.name).toEqual(name + '2');
+    });
+
+    it('finds empty documents as new model', async () => {
+        const containerUrl = fakeContainerUrl();
+        const resourceDocumentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl: resourceDocumentUrl });
+
+        FakeSolidEngine.database[containerUrl] = {
+            [resourceDocumentUrl]: { '@graph': [] },
+        };
+
+        // Act
+        const model = await MultiDocumentWebId.find(resourceUrl);
+
+        // Assert
+        expect(model).not.toBeNull();
+        expect(model?.getParts().length).toEqual(1);
+        expect(model?.getParts()[0]?.name).toBeUndefined();
+    });
+
+    it('loads additional parts with start in specified document', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const resourceDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'res' });
+        const resourceUrl = fakeResourceUrl({ documentUrl: resourceDocumentUrl });
+        const additionalDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'main' });
+        const linkedDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'other' });
+
+        const name = faker.name.firstName();
+
+        const model = new MultiDocumentWebId(resourceUrl);
+        const firstPart = new WebId({ url: resourceUrl, name: name + '0' });
+        firstPart.setSourceDocumentUrl(resourceDocumentUrl);
+        model.addPart(firstPart);
+
+        FakeSolidEngine.database[containerUrl] = {
+            [additionalDocumentUrl]: stubWebIdJsonLD(
+                resourceUrl,
+                name + '1',
+                [],
+                [linkedDocumentUrl, resourceDocumentUrl],
+            ),
+            [linkedDocumentUrl]: stubWebIdJsonLD(resourceUrl, name + '2'),
+        };
+
+        // Act
+        await model.loadFromLinkedDocuments(additionalDocumentUrl);
+
+        // Assert
+        expect(model?.getParts().length).toEqual(3);
+        expect(model?.getParts()[0]?.name).toEqual(name + '0');
+        expect(model?.getParts()[1]?.name).toEqual(name + '1');
+        expect(model?.getParts()[2]?.name).toEqual(name + '2');
+    });
+
+    it('merges properties of all parts', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const firstDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'main' });
+        const secondDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'second' });
+        const thirdDocumentUrl = fakeDocumentUrl({ containerUrl, name: 'third' });
+        const resourceUrl = fakeResourceUrl({ documentUrl: firstDocumentUrl });
+
+        const name = faker.name.firstName();
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const knownPersons = [
+            new Person({ name: name + 'p1' }),
+            new Person({ name: name + 'p2' }),
+            new Person({ name: name + 'p3' }),
+        ];
+
+        const part1 = new WebId({ url: resourceUrl, name: name + '1', seeAlso: [secondDocumentUrl] });
+        part1.setSourceDocumentUrl(firstDocumentUrl);
+        part1.relatedKnownPersons.attach(knownPersons[0]);
+        part1.relatedKnownPersons.attach(knownPersons[1]);
+
+        const part2 = new WebId({ url: resourceUrl, name: name + '2', seeAlso: [thirdDocumentUrl] });
+        part2.setSourceDocumentUrl(secondDocumentUrl);
+        part1.relatedKnownPersons.attach(knownPersons[2]);
+
+        const part3 = new WebId({ url: resourceUrl, name: null, isPrimaryTopicOf: [null, undefined] });
+        part3.setSourceDocumentUrl(thirdDocumentUrl);
+
+        // Act
+        model.addPart(part1);
+        model.addPart(part2);
+        model.addPart(part3);
+
+        // Assert
+        expect(model.getParts().length).toEqual(3);
+        expect(model.name).toEqual([name + '1', name + '2']);
+        expect(model.knows).toEqual([]);
+        expect(model.seeAlso).toEqual([secondDocumentUrl, thirdDocumentUrl]);
+        expect(model.isPrimaryTopicOf).toEqual([]);
+        expect(model.knownPersons).toEqual(knownPersons);
+    });
+
+    it('doesn\'t allow parts without source document url', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+
+        const model = new MultiDocumentWebId(resourceUrl);
+        const part = new WebId({ url: resourceUrl, name: faker.name.firstName() });
+
+        // Act + Assert
+        await expect(() => model.addPart(part)).rejects.toThrow('source document url set');
+    });
+
+    it('doesn\'t allow parts with different id', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl, hash: 'res' });
+        const otherResourceUrl = fakeResourceUrl({ documentUrl, hash: 'other' });
+
+        const model = new MultiDocumentWebId(resourceUrl);
+        const part = new WebId({ url: otherResourceUrl, name: faker.name.firstName() });
+        part.setSourceDocumentUrl(documentUrl);
+
+        // Act + Assert
+        await expect(() => model.addPart(part)).rejects.toThrow('same primary key');
+    });
+
+    it('automaticaly sets id for added parts', async () => {
+        // Arrange
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+
+        const model = new MultiDocumentWebId(resourceUrl);
+        const part = new WebId();
+        part.setSourceDocumentUrl(documentUrl);
+
+        // Act
+        model.addPart(part);
+
+        // Assert
+        expect(model.getParts().length).toEqual(1);
+        expect(part.getSerializedPrimaryKey()).toEqual(resourceUrl);
+    });
+
+    it('triggers event when part is modified', async () => {
+        // Arrange
+        let count = 0;
+        let modifiedDoc = null;
+        let modifiedPart = null;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId();
+        part.setSourceDocumentUrl(documentUrl);
+
+        await model.addPart(part);
+
+        model.on('part-modified', (m, p) => { 
+            count++;
+            modifiedDoc = m;
+            modifiedPart = p;
+        });
+
+        // Act
+        part.name = faker.name.firstName();
+
+        // Assert
+        expect(count).toEqual(1);
+        expect(modifiedDoc).toEqual(model);
+        expect(modifiedPart).toEqual(part);
+    });
+
+    it('triggers event when part is created', async () => {
+        // Arrange
+        let count = 0;
+        let updatedDoc = null;
+        let updatedPart = null;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId();
+        part.setSourceDocumentUrl(documentUrl);
+
+        await model.addPart(part);
+
+        model.on('part-created', (m, p) => { 
+            count++;
+            updatedDoc = m;
+            updatedPart = p;
+        });
+
+        // Act
+        part.name = faker.name.firstName();
+        await part.save();
+
+        // Assert
+        expect(count).toEqual(1);
+        expect(updatedDoc).toEqual(model);
+        expect(updatedPart).toEqual(part);
+    });
+
+    it('triggers event when part is updated', async () => {
+        // Arrange
+        let count = 0;
+        let updatedDoc = null;
+        let updatedPart = null;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId({}, true);
+        part.setSourceDocumentUrl(documentUrl);
+
+        FakeSolidEngine.database[containerUrl] = {
+            [documentUrl]: {
+                '@graph': [
+                    part.toJsonLD() as EngineDocument,
+                ],
+            },
+        };
+
+        await model.addPart(part);
+
+        model.on('part-updated', (m, p) => { 
+            count++;
+            updatedDoc = m;
+            updatedPart = p;
+        });
+
+        // Act
+        part.name = faker.name.firstName();
+        await part.save();
+
+        // Assert
+        expect(count).toEqual(1);
+        expect(updatedDoc).toEqual(model);
+        expect(updatedPart).toEqual(part);
+    });
+
+    it('triggers event when relation of part is loaded', async () => {
+        // Arrange
+        let count = 0;
+        let updatedDoc = null;
+        let updatedPart = null;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const personResourceUrl = fakeResourceUrl({ documentUrl, hash: 'person' });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId({}, true);
+        part.setSourceDocumentUrl(documentUrl);
+
+        FakeSolidEngine.database[containerUrl] = {
+            [documentUrl]: stubPersonJsonLD(personResourceUrl, faker.name.firstName()),
+        };
+
+        await model.addPart(part);
+
+        model.on('part-relation-loaded', (m, p) => { 
+            count++;
+            updatedDoc = m;
+            updatedPart = p;
+        });
+
+        // Act
+        await part.loadRelation('knownPersons');
+
+        // Assert
+        expect(count).toEqual(1);
+        expect(updatedDoc).toEqual(model);
+        expect(updatedPart).toEqual(part);
+    });
+
+    it('triggers event when part is deleted', async () => {
+        // Arrange
+        let count = 0;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId({ url: resourceUrl }, true);
+        part.setSourceDocumentUrl(documentUrl);
+        await model.addPart(part);
+
+        FakeSolidEngine.database[containerUrl] = {
+            [documentUrl]: {
+                '@graph': [
+                    part.toJsonLD() as EngineDocument,
+                ],
+            },
+        };
+
+        model.on('part-deleted', () => count++);
+
+        // Act
+        await part.delete();
+
+        // Assert
+        expect(count).toEqual(1);
+    });
+
+    it('triggers event when part is added', async () => {
+        // Arrange
+        let count = 0;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId();
+        part.setSourceDocumentUrl(documentUrl);
+
+        model.on('part-added', () => count++);
+
+        // Act
+        await model.addPart(part);
+
+        // Assert
+        expect(count).toEqual(1);
+    });
+
+    it('triggers event when part is removed', async () => {
+        // Arrange
+        let count = 0;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        const part = new WebId();
+        part.setSourceDocumentUrl(documentUrl);
+        await model.addPart(part);
+
+        model.on('part-removed', () => count++);
+
+        // Act
+        await model.removePart(part);
+
+        // Assert
+        expect(count).toEqual(1);
+    });
+
+    it('doesn\'t trigger event when part removal is not successful', async () => {
+        // Arrange
+        let count = 0;
+
+        const containerUrl = fakeContainerUrl();
+        const documentUrl = fakeDocumentUrl({ containerUrl });
+        const resourceUrl = fakeResourceUrl({ documentUrl });
+        const model = new MultiDocumentWebId(resourceUrl);
+
+        model.on('part-removed', () => count++);
+
+        // Act
+        await model.removePart(new WebId());
+
+        // Assert
+        expect(count).toEqual(0);
+    });
+
+});

--- a/packages/soukai-solid/src/models/SolidMultiDocumentModel.ts
+++ b/packages/soukai-solid/src/models/SolidMultiDocumentModel.ts
@@ -1,0 +1,303 @@
+import { type Constructor, arrayRemove, isInstanceOf, urlRoute } from '@noeldemartin/utils';
+import { SoukaiError } from 'soukai';
+import { ResourceNotFound } from 'soukai-solid/errors';
+
+import { type SolidModel } from 'soukai-solid/models/SolidModel';
+
+type SolidMultiDocumentModelListener<T extends SolidModel> = 
+    (multiDocument: SolidMultiDocumentModel<T>, part: T | undefined) => unknown;
+
+type SolidMultiDocumentConstructor<T extends SolidMultiDocumentModel<F>, F extends SolidModel> = 
+    Constructor<T> & typeof SolidMultiDocumentModel<F>;
+
+const SolidMultiDocumentModelEventTypes = {
+    'part-created': ['created'],
+    'part-modified': ['modified'],
+    'part-updated': ['updated'],
+    'part-deleted': ['deleted'],
+    'part-relation-loaded': ['relation-loaded'],
+    'part-added': [],
+    'part-removed': [],
+} as const;
+type SolidMultiDocumentModelEventTypes = keyof typeof SolidMultiDocumentModelEventTypes;
+
+export class SolidMultiDocumentModel<T extends SolidModel> {
+
+    public static baseModel: typeof SolidModel;
+    public static linkedByAttributes: string[];
+    private _parts: T[] = [];
+    private _proxy;
+    private _id: string;
+    private _eventHandlers: Record<string, SolidMultiDocumentModelListener<T>[]> = {};
+
+    constructor(id: string) {
+        this._id = id;
+
+        if (!this.static().baseModel) {
+            throw new SoukaiError('There is no base model class specified. Use multiDocumentModelOf function.');
+        }
+
+        this._proxy = new Proxy(this, {
+            get(target, property, receiver) {
+                if (property in target) {
+                    return Reflect.get(target, property, receiver);
+                }
+
+                if (property in target.static().baseModel.fields) {
+                    return target.mergeValuesFromParts(property.toString());
+                }
+
+                if (typeof property === 'string' && target.static().baseModel.relations.includes(property)) {
+                    return target.mergeRelationValuesFromParts(property);
+                }
+
+                return undefined;
+            },
+        });
+        return this._proxy;
+    }
+
+    /**
+     * Creates an instance multi document model with the given key and attempts to load all linked parts
+     * ({@link loadFromLinkedDocuments}).
+     * @param key The identifier of the entity
+     * @param firstDocumentUrl The first document to search in. If not specified, the key is used as a URL instead.
+     * @returns New instance of multi document model
+     */
+    public static async find<F extends SolidModel, T extends SolidMultiDocumentModel<F>>(
+        this: SolidMultiDocumentConstructor<T, F>,
+        key: string,
+        firstDocumentUrl?: string,
+    ): Promise<T | null> {
+        const result = new this(key);
+
+        this.baseModel.ensureBooted();
+
+        firstDocumentUrl ??= urlRoute(key);
+
+        await result.loadFromLinkedDocuments(firstDocumentUrl);
+
+        if (result._parts.length === 0) {
+            return null;
+        }
+
+        return result;
+    }
+
+    /**
+     * Recursively gather links of all parts and load them into the instance.
+     * It does not load a document if there is already a part from that document.
+     * If it is possible to load a document, but there is no suitable entity in it, a new part is created.
+     * @param firstDocumentUrl The first document to search in.
+     */
+    public async loadFromLinkedDocuments(firstDocumentUrl?: string): Promise<void> {
+        const foundDocumentUrls = new Set(this._parts.map(p => p.getSourceDocumentUrl()));
+        
+        let documentsUrlsForSearch = firstDocumentUrl ? [firstDocumentUrl] : this.getLinkedByValues(this._parts);
+        while (documentsUrlsForSearch.length > 0) {
+            const downloadPromises = [];
+            for (const documentUrl of documentsUrlsForSearch) {
+                if (foundDocumentUrls.has(documentUrl)) {
+                    continue;
+                }
+                
+                foundDocumentUrls.add(documentUrl);
+                downloadPromises.push(
+                    this.static().baseModel.findOrFail(this._id, documentUrl)
+                        .catch(error => {
+                            if (isInstanceOf(error, ResourceNotFound)) {
+                                const instance = this.static().baseModel.newInstance({
+                                    [this.static().baseModel.primaryKey]: this._id,
+                                });
+                                instance.setDocumentExists(true);
+                                instance.setSourceDocumentUrl(documentUrl);
+                                return instance;
+                            }
+                            return null;
+                        }),
+                );
+            }
+
+            const models = (await Promise.all(downloadPromises)).filter(m => m !== null);
+            this._parts.push(...(models as T[]));
+            
+            documentsUrlsForSearch = this.getLinkedByValues(models);
+        }
+    }
+
+    /**
+     * Saves all parts that are dirty.
+     */
+    public async save(): Promise<void> {
+        for (const part of this._parts) {
+            await part.save();
+        }
+    }
+
+    /**
+     * Identifier of the entity.
+     */
+    public get id(): string {
+        return this._id;
+    }
+
+    /**
+     * Returns a snapshot of all loaded parts that contain data for this entity.
+     * Modifications to the returned array have no effect.
+     * Use {@link addPart} and {@link removePart} to make modifications.
+     * @returns A snapshot of current parts of the entity
+     */
+    public getParts(): readonly T[] {
+        return [...this._parts];
+    }
+
+    /**
+     * Adds an entity to the multi document entity as its part.
+     * The part has to have a source document url and no or correct primary key.
+     * If the part does not have a primary key, it is set automatically.
+     * @param part A part to be added
+     */
+    public async addPart(part: T): Promise<void> {
+        if (part.getSourceDocumentUrl() === null) {
+            throw new SoukaiError('All parts of multi document model must have their source document url set.');
+        }
+
+        if (part.getSerializedPrimaryKey() === null) {
+            part.setAttribute(this.static().baseModel.primaryKey, this._id);
+        }
+
+        if (part.getSerializedPrimaryKey() !== this._id) {
+            throw new SoukaiError('All parts of multi document model must have the same primary key.');
+        }
+
+        this._parts.push(part);
+
+        await this.emitEvent('part-added', part);
+    }
+
+    /**
+     * Removes the given part from the multi document entity.
+     * @param part A part to be removed
+     * @returns true if the part was included in the entity; otherwise, false
+     */
+    public async removePart(part: T): Promise<boolean> {
+        const wasChanged = arrayRemove(this._parts, part);
+        if (wasChanged) {
+            await this.emitEvent('part-removed', part);
+        }
+        return wasChanged;
+    }
+
+    /**
+     * Adds an event listener to this instance
+     * @param event Type of event
+     * @param listener Listener that is triggered by the event
+     * @returns A function that unregisters the event
+     */
+    public on(
+        event: SolidMultiDocumentModelEventTypes, 
+        listener: SolidMultiDocumentModelListener<T>,
+    ): () => void {
+        const eventListeners = (this._eventHandlers[event] ??= []);
+        
+        eventListeners.push(listener);
+
+        const baseListeners = SolidMultiDocumentModelEventTypes[event];
+        const baseListenersDestroyers: (() => void)[] = [];
+
+        for (const baseListener of baseListeners) {
+            const listenerDestroyer = this.static().baseModel.on(baseListener, (...args) => {
+                const part = args[0] as T;
+                if (this._parts.includes(part)) {
+                    this.emitEvent(event, part);
+                }
+            });
+            baseListenersDestroyers.push(listenerDestroyer);
+        }
+    
+        return () => {
+            arrayRemove(eventListeners, listener);
+            baseListenersDestroyers.forEach(destroyer => destroyer());
+        };
+    }
+
+    /**
+     * Emits an event for all listeners registered for the event type.
+     * @param event Event type to be emitted
+     * @param part Part that triggered the event
+     */
+    protected async emitEvent(event: SolidMultiDocumentModelEventTypes, part?: T): Promise<void> {
+        const eventListeners = this._eventHandlers[event] ?? [];
+
+        await Promise.all(eventListeners.map(listener => listener(this, part)));
+    }
+
+    protected static<BM extends SolidModel, M extends typeof SolidMultiDocumentModel<BM>>(): M {
+        return this.constructor as M;
+    }
+
+    /**
+     * Search all given instances for values of linked attributes and returns an array of all found values.
+     * @param models Instances to be searched
+     * @returns Non-unique list of found values
+     */
+    private getLinkedByValues(models: SolidModel[]): string[] {
+        const foundValues = [];
+
+        const linkedByAttributes = this.static().linkedByAttributes;
+
+        for (const model of models) {
+            for (const linkedByAttribute of linkedByAttributes) {
+                const links = model.getAttribute(linkedByAttribute) as undefined|string|string[];
+                if (Array.isArray(links)) {
+                    foundValues.push(...links);
+                } else if (links !== undefined) {
+                    foundValues.push(links);
+                }
+            }
+        }
+
+        return foundValues;
+    }
+
+    /**
+     * Merges values of the given attribute/property to a single array
+     * @param property Name of the attribute/property
+     * @returns An array of values from all parts
+     */
+    private mergeValuesFromParts(property: string): unknown[] {
+        return this.mergeFromParts(part => part.getAttribute(property));
+    }
+
+    /**
+     * Creates a single list of all entities from the given relation
+     * @param relation Name of the relation
+     * @returns An array of related entities from all parts
+     */
+    private mergeRelationValuesFromParts(relation: string): unknown[] {
+        return this.mergeFromParts(part => 
+            part.isRelationLoaded(relation) 
+                ? part.requireRelation(relation).related
+                : undefined);
+    }
+
+    /**
+     * Applies the given getter to all parts and puts all received values into a single array.
+     * If an array is returned from the getter, it is merged with a flat array.
+     * @param valueGetter Function that returns a value for each part of the entity
+     * @returns An array of values from all parts
+     */
+    private mergeFromParts(valueGetter: (part: T) => unknown|unknown[]): unknown[] {
+        const result: unknown[] = [];
+        for (const part of this.getParts()) {
+            const value = valueGetter(part);
+            if (Array.isArray(value)) {
+                result.push(...value.filter(v => v !== undefined && v != null));
+            } else if (value !== undefined && value !== null) {
+                result.push(value);
+            }
+        }
+        return result;
+    }
+
+}

--- a/packages/soukai-solid/src/models/fields.ts
+++ b/packages/soukai-solid/src/models/fields.ts
@@ -121,7 +121,7 @@ export type SolidSchemaDefinition = SchemaDefinition<{
     Partial<{
         rdfContext: string;
         rdfContexts: Record<string, string>;
-        rdfsClass: string;
+        rdfsClass: string | null;
         rdfsClasses: string[];
         rdfsClassesAliases: string[][];
         defaultResourceHash: string;

--- a/packages/soukai-solid/src/models/index.ts
+++ b/packages/soukai-solid/src/models/index.ts
@@ -19,6 +19,7 @@ export * from './schema';
 export * from './schema-container';
 export * from './SolidModel';
 export * from './SolidContainer.schema';
+export * from './SolidMultiDocumentModel';
 
 export { SolidACLAuthorization, SolidContainer, SolidDocument, SolidResource, SolidTypeIndex, SolidTypeRegistration };
 

--- a/packages/soukai-solid/src/models/inference.ts
+++ b/packages/soukai-solid/src/models/inference.ts
@@ -8,7 +8,7 @@ import type { SolidModel } from './SolidModel';
 export type SolidMagicAttributes<
     S extends SolidSchemaDefinition,
     F extends SolidFieldsDefinition = GetFieldsDefinition<S>,
-> = Pretty<MagicAttributes<S, string> & MagicAttributeProperties<Pick<F, GetArrayFields<F>>, string>>;
+> = Pretty<MagicAttributes<S, string, 'url'> & MagicAttributeProperties<Pick<F, GetArrayFields<F>>, string>>;
 
 export type SolidModelConstructor<T extends SolidModel = SolidModel> = Constructor<T> & typeof SolidModel;
 export type SolidContainerConstructor<T extends SolidContainer = SolidContainer> = Constructor<T> &

--- a/packages/soukai-solid/src/models/inference.ts
+++ b/packages/soukai-solid/src/models/inference.ts
@@ -1,5 +1,5 @@
 import type { Constructor, Pretty } from '@noeldemartin/utils';
-import type { GetArrayFields, GetFieldsDefinition, MagicAttributeProperties, MagicAttributes } from 'soukai';
+import type { GetArrayFields, GetFieldsDefinition, MagicAttributeProperties, MagicAttributes, Relation } from 'soukai';
 
 import type SolidContainer from './SolidContainer';
 import type { SolidFieldsDefinition, SolidSchemaDefinition } from './fields';
@@ -13,3 +13,8 @@ export type SolidMagicAttributes<
 export type SolidModelConstructor<T extends SolidModel = SolidModel> = Constructor<T> & typeof SolidModel;
 export type SolidContainerConstructor<T extends SolidContainer = SolidContainer> = Constructor<T> &
     typeof SolidContainer;
+
+export type PropertiesOnly<T> = { [P in keyof T as Exclude<P, T[P] extends (Function | Relation) ? P : never>]: T[P] };
+export type ReadOnlyFlatArray<T> = { [P in keyof T]: readonly (T[P] extends unknown[] ? T[P][number] : T[P])[]};
+export type MultiDocumentDelegate<T> = 
+    Readonly<ReadOnlyFlatArray<Required<PropertiesOnly<Omit<T, keyof SolidModel>>>>>;

--- a/packages/soukai-solid/src/models/internals/JsonLDModelSerializer.ts
+++ b/packages/soukai-solid/src/models/internals/JsonLDModelSerializer.ts
@@ -169,7 +169,7 @@ export default class JsonLDModelSerializer {
             this.setJsonLDRelations(jsonld, model, ignoredModels);
         }
 
-        if (options.includeTypes ?? true) {
+        if ((options.includeTypes ?? true) && model.static('rdfsClasses').length > 0) {
             this.setJsonLDTypes(jsonld, model);
         } else {
             delete jsonld['@type'];

--- a/packages/soukai-solid/src/models/schema.ts
+++ b/packages/soukai-solid/src/models/schema.ts
@@ -2,8 +2,9 @@ import type { Constructor } from '@noeldemartin/utils';
 
 import { bootSolidSchemaDecoupled, defineSolidModelSchemaDecoupled } from './internals/helpers';
 import { SolidModel } from './SolidModel';
-import type { SolidMagicAttributes, SolidModelConstructor } from './inference';
+import type { MultiDocumentDelegate, SolidMagicAttributes, SolidModelConstructor } from './inference';
 import type { SolidSchemaDefinition } from './fields';
+import { SolidMultiDocumentModel } from './SolidMultiDocumentModel';
 
 export function bootSolidSchema<BaseModel extends SolidModel, Schema extends SolidSchemaDefinition>(
     baseModelOrDefinition: SolidModelConstructor<BaseModel> | Schema,
@@ -27,4 +28,24 @@ export function defineSolidModelSchema<BaseModel extends SolidModel, Schema exte
     definition?: Schema,
 ): Constructor<SolidMagicAttributes<Schema>> & SolidModelConstructor<BaseModel> {
     return defineSolidModelSchemaDecoupled(baseModelOrDefinition, SolidModel, definition);
+}
+
+/**
+ * Creates a specialized class based on the {@link SolidMultiDocumentModel}
+ * which consists of the instances of the given model.
+ * @param model {@link SolidModel} from which the multi document model is build
+ * @param linkedBy List of attributes that are used to find other linked parts of the entity.
+ * @returns Class based on {@link SolidMultiDocumentModel}
+ */
+export function multiDocumentModelOf<F extends typeof SolidModel, T extends SolidModel>(
+    model: F & Constructor<T>, 
+    linkedBy: keyof MultiDocumentDelegate<T>|(keyof MultiDocumentDelegate<T>)[],
+): Constructor<MultiDocumentDelegate<T>> & typeof SolidMultiDocumentModel<T> {
+    const modelClass = (class extends SolidMultiDocumentModel<T> {}) as
+        Constructor<MultiDocumentDelegate<T>> & typeof SolidMultiDocumentModel<T>;
+    if (!Array.isArray(linkedBy)) {
+        linkedBy = [linkedBy];
+    }
+    Object.assign(modelClass, { baseModel: model, linkedByAttributes: linkedBy });
+    return modelClass;
 }

--- a/packages/soukai-solid/src/testing/lib/stubs/ModelWithCustomKey.schema.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/ModelWithCustomKey.schema.ts
@@ -1,0 +1,13 @@
+import { FieldType } from 'soukai';
+import { defineSolidModelSchema } from 'soukai-solid/models';
+
+export default defineSolidModelSchema({
+    rdfContexts: { foaf: 'http://xmlns.com/foaf/0.1/' },
+    primaryKey: 'customKey' as const,
+    fields: {
+        age: {
+            type: FieldType.Number,
+            rdfProperty: 'foaf:age',
+        },
+    },
+});

--- a/packages/soukai-solid/src/testing/lib/stubs/ModelWithCustomKey.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/ModelWithCustomKey.ts
@@ -1,0 +1,3 @@
+import Model from './ModelWithCustomKey.schema';
+
+export default class ModelWithCustomKey extends Model {}

--- a/packages/soukai-solid/src/testing/lib/stubs/ModelWithoutType.schema.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/ModelWithoutType.schema.ts
@@ -1,0 +1,11 @@
+import { FieldType } from 'soukai';
+import { defineSolidModelSchema } from 'soukai-solid/models';
+
+export default defineSolidModelSchema({
+    rdfContext: 'http://xmlns.com/foaf/0.1/',
+    rdfsClass: null,
+    timestamps: false,
+    fields: {
+        age: FieldType.Number,
+    },
+});

--- a/packages/soukai-solid/src/testing/lib/stubs/ModelWithoutType.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/ModelWithoutType.ts
@@ -1,0 +1,3 @@
+import Model from './ModelWithoutType.schema';
+
+export default class ModelWithoutType extends Model {}

--- a/packages/soukai-solid/src/testing/lib/stubs/MultiDocumentWebId.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/MultiDocumentWebId.ts
@@ -1,0 +1,6 @@
+import { multiDocumentModelOf } from 'soukai-solid/models';
+import WebId from './WebId';
+
+const Model = multiDocumentModelOf(WebId, ['seeAlso', 'isPrimaryTopicOf']);
+
+export class MultiDocumentWebId extends Model {}

--- a/packages/soukai-solid/src/testing/lib/stubs/WebId.schema.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/WebId.schema.ts
@@ -1,0 +1,27 @@
+import { FieldType } from 'soukai';
+import { defineSolidModelSchema } from 'soukai-solid/models';
+
+export default defineSolidModelSchema({
+    rdfsClass: null,
+    fields: {
+        name: {
+            type: FieldType.String,
+            rdfProperty: 'foaf:name',
+        },
+        knows: {
+            type: FieldType.Array,
+            items: FieldType.Key,
+            rdfProperty: 'foaf:knows',
+        },
+        seeAlso: {
+            type: FieldType.Array,
+            items: FieldType.Key,
+            rdfProperty: 'rdfs:seeAlso',
+        },
+        isPrimaryTopicOf: {
+            type: FieldType.Array,
+            items: FieldType.Key,
+            rdfProperty: 'foaf:isPrimaryTopicOf',
+        },
+    },
+});

--- a/packages/soukai-solid/src/testing/lib/stubs/WebId.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/WebId.ts
@@ -1,0 +1,14 @@
+import { type BelongsToManyRelation, type Relation } from 'soukai';
+import Person from './Person';
+import Model from './WebId.schema';
+
+export default class WebId extends Model {
+
+    declare public knownPersons?: Person[];
+    declare public relatedKnownPersons: BelongsToManyRelation<this, Person, typeof Person>;
+
+    public knownPersonsRelationship(): Relation {
+        return this.belongsToMany(Person, 'knows');
+    }
+
+}

--- a/packages/soukai-solid/src/testing/lib/stubs/helpers.ts
+++ b/packages/soukai-solid/src/testing/lib/stubs/helpers.ts
@@ -155,6 +155,38 @@ export function stubSolidDocumentJsonLD(url: string, updatedAt: string): JsonLDG
     });
 }
 
+export function stubWebIdJsonLD(
+    id: string,
+    name: string,
+    knows?: string[] | undefined,
+    seeAlso?: string[] | undefined,
+    isPrimaryTopicOf?: string[] | undefined,
+): JsonLDGraph & EngineDocument {
+    const webId: JsonLDResource = {
+        '@context': {
+            rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+            foaf: 'http://xmlns.com/foaf/0.1/',
+        },
+        '@id': id,
+        'foaf:name': name,
+    };
+    
+    if (knows !== undefined) {
+        webId['foaf:knows'] = knows;
+    }
+
+    if (seeAlso !== undefined) {
+        webId['rdfs:seeAlso'] = seeAlso;
+    }
+
+    if (isPrimaryTopicOf !== undefined) {
+        webId['foaf:isPrimaryTopicOf'] = isPrimaryTopicOf;
+    }
+
+    return jsonLDGraph(webId);
+}
+
+
 export function jsonLDGraph(...resources: JsonLDResource[]): JsonLDGraph & EngineDocument {
     return { '@graph': resources } as JsonLDGraph & EngineDocument;
 }

--- a/packages/soukai/src/models/Model.ts
+++ b/packages/soukai/src/models/Model.ts
@@ -148,19 +148,17 @@ export class Model {
     }
 
     public static async findOrFail<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T> {
-        const instance = await this.find(id);
+        this.ensureBooted();
 
-        return instance ?? fail(`Failed getting required model ${id}`);
+        const document = await this.requireEngine().readOne(this.collection, this.instance().serializeKey(id));
+        const instance = await this.createFromEngineDocument(id, document);
+
+        return instance;
     }
 
     public static async find<T extends Model>(this: ModelConstructor<T>, id: Key): Promise<T | null> {
-        this.ensureBooted();
-
         try {
-            const document = await this.requireEngine().readOne(this.collection, this.instance().serializeKey(id));
-            const instance = await this.createFromEngineDocument(id, document);
-
-            return instance;
+            return await this.findOrFail(id);
         } catch (error) {
             return null;
         }

--- a/packages/soukai/src/models/inference.ts
+++ b/packages/soukai/src/models/inference.ts
@@ -24,7 +24,11 @@ import type { TimestampField, TimestampsDefinition } from './timestamps';
 
 export type ModelConstructor<T extends Model = Model> = Constructor<T> & typeof Model;
 
-export type MagicAttributes<S extends SchemaDefinition, TKey extends Key> = Pretty<
+export type MagicAttributes<
+    S extends SchemaDefinition,
+    TKey extends Key,
+    TDefaultKeyName extends string = 'id'
+> = Pretty<
     MagicAttributeProperties<
         {
             // TODO this should be optional (but it's too annoying to use)
@@ -34,6 +38,7 @@ export type MagicAttributes<S extends SchemaDefinition, TKey extends Key> = Pret
     > &
         // TODO infer virtual attributes
         // TODO infer relationship attributes
+        MagicPrimaryKeyAttribute<S, TDefaultKeyName, TKey> &
         NestedMagicAttributes<GetFieldsDefinition<S>, TKey> &
         MagicTimestampAttributes<GetTimestampsDefinition<S>>
 >;
@@ -45,6 +50,13 @@ export type MagicTimestampAttributes<T extends TimestampsDefinition> = T extends
       : T extends (typeof TimestampField.UpdatedAt)[]
         ? { updatedAt: Date }
         : { createdAt: Date; updatedAt: Date };
+
+export type MagicPrimaryKeyAttribute<S extends SchemaDefinition, TDefaultKeyName extends string, TKey extends Key> = 
+    S extends { primaryKey: infer P extends string }
+        ? string extends P 
+            ? {}
+            : MagicAttributeProperties<{[C in P]: typeof FieldType.Key}, TKey>
+        : MagicAttributeProperties<{[C in TDefaultKeyName]: typeof FieldType.Key}, TKey>;
 
 export type NestedMagicAttributes<T extends FieldsDefinition, TKey extends Key> = MagicAttributeProperties<
     Pick<T, GetRequiredFields<T>>,


### PR DESCRIPTION
## Motivation

The first thing that has to be done by the application after the user is logged in is to load their WebId document. However, WebId may have a rather complicated structure. There may be single resource containing all information. There can be separate WebId resource and Extended Profile resource. But the most problematic situation is WebId spanning over multiple resources linked by the `rdfs:seeAlso` predicate. In order to load the whole WebId document, application has to traverse all resources linked by `rdfs:seeAlso`. These other resources can contain triples with the URL of the WebId as their subject and provide additional details. In such case the subject's IRI will not match the URL of the resource. Also, it is to be expected that these resources won't contain the type of the resource, because it is already specified in a different resource.

This PR gives the Soukai the ability to fulfill this use-case by separing URL of the document and primary key and by adding a `SolidMultiDocumentModel` which can load all linked resources recursivelly and merge the loaded data. In order to implement this feature, it was necessary to do some changes to the library. All of these changes should not change the behavior of the library for most of the applications that currently use it. I tested all modifications together, but to make code review easier, I split the changes to multiple commits.

## SolidMultiDocumentModel

The `SolidMultiDocumentModel` is a class that consists of multiple entities of a single model and provides each of their attributes as a merged array of all values. In order to provide a way to modify the data, each entity that is part of the `SolidMultiDocumentModel` can be modified and saved separately.

To use it, the developer has to create a subclass of `SolidMultiDocumentModel` using `multiDocumentModelOf` function which is similar to `defineSolidModelSchema`. It takes a `SolidModel` and a list of its traversable attributes that denotes where other entities of the same model can be found (such as `rdfs:seeAlso`). This way the developer can create e.g. `MultiDocumentWebId` based on a `WebId` model:

```ts
const WebIdModel = defineSolidModelSchema({
    fields: {
        'name': {
            rdfProperty: 'foaf:name',
            type: FieldType.String,
        },
        'seeAlso': {
            rdfProperty: 'rdfs:seeAlso',
            type: FieldType.Array,
            items: FieldType.Key,
        },
    },
});

class WebId extends WebIdModel {
}

const MultiDocumentWebId = multiDocumentModelOf(WebId, 'seeAlso');
```

The `multiDocumentModelOf` function tries to deduct all attributes of the given model and provide class that has TypeScript definitions. Values of relations are also supported. All attributes are changed to an array of their type which contains values found in all parts merged together. In case of array attributes, arrays are merged into a single array instead of array of arrays.

An instance can be created using constructor or the static `find` method. In both cases the IRI has to be specified, which is then enforced on all parts and used during loading of linked documents. Individual parts can be accessed using `getParts` method. Changes to `SolidMultiDocumentModel` can be observed using events that are registered in similar way as they are for `Model`. The major difference here is that events are registered on instance instead of class. This is because the `SolidMultiDocumentModel` needs to register listener to underlying class to trigger its own events when any part is changed. To add or remove parts, specialized methods have to be used, because they also trigger events.

## Document URL

The URL of the document in which the resource is located is currently always based on the `url` attribute of the SolidModel. It is therefore not possible to save an entity to a document that is not matching this attribute. Also, there is a discrepancy between the usage of primary key and `url` attribute. In the default state these two are equivalent, but if the developer decides to change the primary key to a different name, the usage of the primary key becomes inconsistent. Therefore, all usages of `url` attribute were removed in the PR and replaced with the use of primary key. This is not a breaking change for developers who did not change the primary key. While this can be a breaking change for developers using SolidModel with custom primary key, I doubt that there are any, because in this case the library behaved unexpectedly. If the primary key is specified with `as const` during the definition of the schema, it is added as magic attribute to the schema.

In order to allow saving entities in different documents, the usage of SourceDocumentUrl, which was set during the load, but never used, was expanded. In the proposed PR the source document URL is the primary source of the document URL. If it is missing, the primary key is used as a fallback corresponding to the current behavior. There is a diffence in behavior when a new entity expects to be saved to a new document, but the document already exists. If the entity has a SourceDocumentUrl, it is saved to the existing document. Otherwise, the behavior remains the same and a new primary key is generated and it is then used for the URL of the document. These changes can affect developers that were changing SourceDocumentUrl and expected that it does not have any effect.

## findOrFail

There are two methods that provide the ability to find an entity by its IRI: `find` and `findOrFail`. The `find` method returns null if any exception is thrown during the loading. The `findOrFail` throws an exception instead. However, the current implementation of `findOrFail` calls the `find` method and throws a generic exception if the `find` method returns null. The application has no mean to react to various reasons of the failure, because the original exception that made the `find` to return null is already lost.

This is also important for the implementation of SolidMultiDocumentModel. When the document exists, but does not contain a matching resource, we do not want to hide the information about the existing linked document from the developer. In such a case the SolidMultiDocumentModel can create a new entity as a placeholder that can be used to add data to the document. In order to do so, it needs a way to distinguish exceptions cause by a missing resource and by a missing document.

To provide the thrown exception, the implementations of `find` and `findOrFail` methods were swapped. In the PR, it is the `findOrFail` method that contains all the logic, while `find` only encapsulates `findOrFail` in try-cache block.

## find in document not matching the URL

When URL of entity and URL of document was linked, it was reasonable that in order to find an entity, the `find` method of the `SoukaiModel` examined the document matching the URL of the entity. However, after the changes regarding source document URL, there should be a way to find an entity with certain URL in a document that is not matching this URL. For this reason, another overload of `find` and `findOrFail` methods was added which has additional argument for URL of the document. This method is then also used in `SolidMultiDocumentModel` to find parts of the entity.

## Model without rdfsClass

The library expects that every entity has a type and provides no way to load a group of triples as an entity. However, when an entity is split into several parts it is very common that type triple is only added to one of the splits that is considered the main one. This introduces a problem for the `SolidMultiDocumentModel`, because in this situation it would only be able to load a single part of entity or it would require a custom implementation for loading of other parts. To solve this issue, it is now possible to specify `rdfsClass` of the model as `null`. If the `rdfsClass` is `null` and there is no type in `rdfsClasses`, the model is considered type-less and type conditions during loading are disabled.